### PR TITLE
ext: depend on colamd library

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 dir_config('lpsolve')
 have_library("dl")
 have_library("m")
+have_library("colamd")
 have_library("lpsolve55_pic") || have_library("lpsolve55") ||  missing("lpsolve55")
 have_header("lpsolve/lp_lib.h") || have_header("lp_lib.h") || missing("lp_lib.h")
 config_file = File.join(File.dirname(__FILE__), 'config_options.rb')


### PR DESCRIPTION
On my Debian Unstable, linking against lpsolve.a is not enough. We also need libcolamd, otherwise the sysamd symbol is not found.
